### PR TITLE
remove request and use native http(s) modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
     "mock-require": "3.0.2",
     "msgpack-lite": "0.1.26",
     "node-watch": "0.5.8",
-    "request": "2.85.0",
     "vscode-jsonrpc": "3.5.0",
     "vscode-languageserver-protocol": "3.9.0",
     "vscode-languageserver-types": "3.5.0"

--- a/src/support/fetch.ts
+++ b/src/support/fetch.ts
@@ -4,7 +4,9 @@ interface FetchOptions extends RequestOptions {
   data?: any
 }
 
-export const fetchStream = (url: string, options = { method: 'GET' } as FetchOptions) => new Promise((done, fail) => {
+type FetchStreamFn = (url: string, options?: FetchOptions) => Promise<IncomingMessage>
+
+export const fetchStream: FetchStreamFn = (url, options = { method: 'GET' }) => new Promise((done, fail) => {
   const { data, ...requestOptions } = options
   const opts = { ...require('url').parse(url), ...requestOptions }
 

--- a/src/support/fetch.ts
+++ b/src/support/fetch.ts
@@ -1,10 +1,15 @@
-// TODO: type the request options
-export const stream = (url: string, options = { method: 'GET' }) => new Promise((done, fail) => {
+import { RequestOptions, IncomingMessage } from 'http'
+
+interface FetchOptions extends RequestOptions {
+  data?: any
+}
+
+export const fetchStream = (url: string, options = { method: 'GET' } as FetchOptions) => new Promise((done, fail) => {
   const { data, ...requestOptions } = options
   const opts = { ...require('url').parse(url), ...requestOptions }
 
-  const req = require(url.startsWith('https://') ? 'https' : 'http').request(opts, res => done(res.statusCode >= 300 && res.statusCode < 400
-    ? stream(res.headers.location, options)
+  const req = require(url.startsWith('https://') ? 'https' : 'http').request(opts, (res: IncomingMessage) => done(res.statusCode! >= 300 && res.statusCode! < 400
+    ? fetchStream(res.headers.location!, options)
     : res))
 
   req.on('error', fail)

--- a/src/support/fetch.ts
+++ b/src/support/fetch.ts
@@ -1,0 +1,13 @@
+// TODO: type the request options
+export const stream = (url: string, options = { method: 'GET' }) => new Promise((done, fail) => {
+  const { data, ...requestOptions } = options
+  const opts = { ...require('url').parse(url), ...requestOptions }
+
+  const req = require(url.startsWith('https://') ? 'https' : 'http').request(opts, res => done(res.statusCode >= 300 && res.statusCode < 400
+    ? stream(res.headers.location, options)
+    : res))
+
+  req.on('error', fail)
+  if (data) req.write(data)
+  req.end()
+})

--- a/src/workers/download.ts
+++ b/src/workers/download.ts
@@ -1,18 +1,23 @@
 import WorkerClient from '../messaging/worker-client'
 import { ensureDir, remove } from '../support/utils'
 import { Archiver } from '../support/binaries'
+import { fetchStream } from '../support/fetch'
 import { createWriteStream } from 'fs'
-import { get } from 'request'
 // not using node built-in http lib because we need error handling and
 // redirects (in the case of github). tried using built-in fetch api, but
 // the stream interface does not seem to be compatible with node's stream api
 
 const { on } = WorkerClient()
 
-const downloadZip = (url: string, path: string) => new Promise(done => get(url)
-  .pipe(createWriteStream(`${path}.zip`))
-  .on('close', done)
-  .on('error', done))
+const downloadZip = (url: string, path: string) => new Promise(async done => {
+  const downloadStream = await fetchStream(url)
+  const fileStream = createWriteStream(`${path}.zip`)
+
+  downloadStream
+    .pipe(fileStream)
+    .on('close', done)
+    .on('error', done)
+})
 
 const unzip = (path: string) => new Promise(done => Archiver(['open', `${path}.zip`, path])
   .on('exit', done)

--- a/src/workers/download.ts
+++ b/src/workers/download.ts
@@ -3,9 +3,6 @@ import { ensureDir, remove } from '../support/utils'
 import { Archiver } from '../support/binaries'
 import { fetchStream } from '../support/fetch'
 import { createWriteStream } from 'fs'
-// not using node built-in http lib because we need error handling and
-// redirects (in the case of github). tried using built-in fetch api, but
-// the stream interface does not seem to be compatible with node's stream api
 
 const { on } = WorkerClient()
 


### PR DESCRIPTION
we have such a simple use case for http, we don't need the heavy request module