### PR TITLE
cleanup neovim modules

### DIFF
--- a/src/neovim/state.ts
+++ b/src/neovim/state.ts
@@ -1,0 +1,4 @@
+// TODO: make it redux compatible. immutable pls
+const state = {
+  mode: 'normal'
+}


### PR DESCRIPTION
a couple problems:

- neovim file is wayyy too big. it does too much
- startup is slow because we send vimscript call by call for static functions
- vim state is not immutable/redux compatible
- there are two states (one in neovim.ts and the other in core/state.ts) the reason for this was module init delay
- can't use neovim module from workers
- duplicates and messy codes in neovim module

todos:

- [ ] make one immutable state to rule them all and in darkness bind them