### PR TITLE
Update cursor.ts so that cursorline height is relative to font size

### DIFF
--- a/src/core/cursor.ts
+++ b/src/core/cursor.ts
@@ -105,6 +105,7 @@ const updateCursorlinePosition = (canvas: CanvasWindow, backgroundColor: string)
     background: hexToRGBA(backgroundColor, 0.2),
     transform: translate(x, y),
     width: `${width}px`,
+    height: `${canvasContainer.cell.height}px`,
   })
 }
 


### PR DESCRIPTION
fixed bug: cursor-line height won't update when font is resized