### PR TITLE
Fix up/down scroll in explorer modals

### DIFF
--- a/src/components/change-project.ts
+++ b/src/components/change-project.ts
@@ -135,7 +135,7 @@ const view = ($: S, a: typeof actions) => Plugin($.visible, [
   ])
 
   ,h('div', {
-    ref: (e: HTMLElement) => {
+    oncreate: (e: HTMLElement) => {
       if (e) listElRef = e
     },
     style: {

--- a/src/components/explorer.ts
+++ b/src/components/explorer.ts
@@ -206,7 +206,7 @@ const view = ($: S, a: A) => Plugin($.vis, [
   })
 
   ,h('div', {
-    ref: (e: HTMLElement) => listElRef = e,
+    oncreate: (e: HTMLElement) => listElRef = e,
     style: {
       maxHeight: '50vh',
       overflowY: 'hidden',

--- a/src/components/messages.ts
+++ b/src/components/messages.ts
@@ -90,7 +90,7 @@ const view = ($: S, a: typeof actions) => h('div', {
   })
 
   ,h('div', {
-    ref: (e: HTMLElement) => {
+    oncreate: (e: HTMLElement) => {
       if (e) elref = e
     },
     style: { overflowY: 'hidden' }


### PR DESCRIPTION
`ref` hook does not exist, the correct hook seems to be `oncreate`.