### PR TITLE
Staging previous editor settings

### DIFF
--- a/src/bootstrap/main.ts
+++ b/src/bootstrap/main.ts
@@ -80,6 +80,10 @@ app.on('ready', async () => {
   win.loadURL(`file:///${__dirname}/index.html`)
   comscan.register((ch, msg) => win.webContents.send(ch, msg))
 
+  if (settingsObject.pageX && settingsObject.pageY) win.setPosition(settingsObject.pageX, settingsObject.pageY)
+  
+  if (settingsObject.isFullscreen === true && win.isFullScreenable()) win.setFullScreen(true)
+
   if (process.env.VEONIM_DEV) {
     function debounce (fn: Function, wait = 1) {
       let timeout: NodeJS.Timer

--- a/src/bootstrap/main.ts
+++ b/src/bootstrap/main.ts
@@ -126,6 +126,19 @@ app.on('ready', async () => {
   }
 })
 
+app.on('before-quit', () => {
+  // Before quitting everything, take a snapshot for the current settings on this session
+  const [ width, height ] = win.getSize();
+  const [ pageX, pageY ] = win.getPosition();
+  settingsHandler().set({
+    width,
+    height,
+    pageX,
+    pageY,
+    isFullscreen: win.isFullScreen() || false,
+  })
+})
+
 const openProcessExplorer = () => {
   if (winProcessExplorer) {
     winProcessExplorer.close()

--- a/src/bootstrap/main.ts
+++ b/src/bootstrap/main.ts
@@ -1,4 +1,5 @@
 import { app, BrowserWindow, Menu, shell } from 'electron'
+import settingsHandler from '../support/settings-handler'
 
 let win: any
 let winProcessExplorer: any

--- a/src/bootstrap/main.ts
+++ b/src/bootstrap/main.ts
@@ -63,8 +63,8 @@ app.on('ready', async () => {
   Menu.setApplicationMenu(Menu.buildFromTemplate(menuTemplate))
 
   win = new BrowserWindow({
-    width: 950,
-    height: 700,
+    width: settingsObject.width || 950,
+    height: settingsObject.height || 700,
     minWidth: 600,
     minHeight: 400,
     frame: true,

--- a/src/bootstrap/main.ts
+++ b/src/bootstrap/main.ts
@@ -12,6 +12,8 @@ const comscan = (() => {
   return { register, dispatch }
 })()
 
+const settingsObject = settingsHandler().get()
+
 app.on('ready', async () => {
   const menuTemplate = [{
     label: 'Window',

--- a/src/support/settings-handler.ts
+++ b/src/support/settings-handler.ts
@@ -1,0 +1,41 @@
+import { readFileSync, writeFileSync, existsSync } from 'fs'
+import { resolve } from 'path'
+
+interface basicIOState {
+    configPath: string,
+}
+
+function parseConfigFile(configPath: string): object {
+    if (existsSync(configPath)) {
+        const settingsConfigString: string = readFileSync(configPath, 'utf8');
+        const settingsJsonObject: object = JSON.parse(settingsConfigString)
+        return settingsJsonObject || null
+    } else {
+        return {};
+    }
+}
+
+const basicIO = (state: basicIOState) => ({
+    get: () => {
+        return parseConfigFile(state.configPath)
+    },
+    set: (newObject: object) => {
+        const oldSettingsJsonObject: object = parseConfigFile(state.configPath)
+        const newSettingsJsonObject = {
+            ...oldSettingsJsonObject,
+            ...newObject
+        }
+        const newSettingsConfigString: string = JSON.stringify(newSettingsJsonObject, null, 4)
+        writeFileSync(state.configPath, newSettingsConfigString)
+    }
+})
+
+export default function settingsHandler() {
+    const state = {
+        configPath: resolve(`${process.env.XDG_CONFIG_HOME}/veonim/settings.json`)
+    }
+    return Object.assign(
+        {},
+        basicIO(state)
+    )
+}


### PR DESCRIPTION
This pull request is mainly for saving the previous state of the editor and re-use to afterward.

For example, when users resized their app window on the previous session, once the re-open Veonim they will get the same settings as before

Current supported options:

* Window Size - Width
* Window Size - Height
* Window Position - X
* Window Position - Y
* App Mode - Full Screen