### PR TITLE
parse non-resolve completion docs if object

### DIFF
--- a/src/components/autocomplete.ts
+++ b/src/components/autocomplete.ts
@@ -126,7 +126,8 @@ const actions = {
       a.showDocs(richFormatDocs)
     })()
 
-    return { ix, documentation: documentation || detail }
+    if (documentation) parseDocs(documentation).then(a.showDocs)
+    return { ix, documentation: detail }
   },
 }
 


### PR DESCRIPTION
Sometimes we get autocomplete documentation back without having to do a resolve request for docs. In this case we are not parsing the documentation if the value is an object.

TODO:

- [x] code fix
- [x] test and verify

see #625